### PR TITLE
ubidy-messagequeueapi to 0.1.42

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -52,3 +52,6 @@ dependencies:
 - name: ubidy-employernotificationapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.39
+- name: ubidy-messagequeueapi
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.1.42


### PR DESCRIPTION
Promote ubidy-messagequeueapi to version 0.1.42