### PR TITLE
ubidy-agencynotificationapi to 0.1.29

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -27,7 +27,7 @@ dependencies:
   version: 0.0.16
 - name: ubidy-agencynotificationapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.24
+  version: 0.1.29
 - name: ubidy-applicationapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.38


### PR DESCRIPTION
Promote ubidy-agencynotificationapi to version 0.1.29