### PR TITLE
ubidy-agencyengagementapi to 0.0.70

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 0.1.113
 - name: ubidy-agencyengagementapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.69
+  version: 0.0.70
 - name: ubidy-agencyengagementboardsapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.29


### PR DESCRIPTION
Promote ubidy-agencyengagementapi to version 0.0.70