### PR TITLE
ubidy-commentssocketapi to 0.1.46

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -36,7 +36,7 @@ dependencies:
   version: 0.0.151
 - name: ubidy-commentssocketapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.45
+  version: 0.1.46
 - name: ubidy-documentapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.33


### PR DESCRIPTION
Promote ubidy-commentssocketapi to version 0.1.46