### PR TITLE
ubidy-commentssocketapi to 0.1.70

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -39,7 +39,7 @@ dependencies:
   version: 0.0.7
 - name: ubidy-commentssocketapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.69
+  version: 0.1.70
 - name: ubidy-documentapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.33


### PR DESCRIPTION
Promote ubidy-commentssocketapi to version 0.1.70