### PR TITLE
ubidy-messagequeueapi to 0.1.54

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -63,7 +63,7 @@ dependencies:
   version: 0.1.61
 - name: ubidy-messagequeueapi
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.1.53
+  version: 0.1.54
 - name: ubidy-messengerapi
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.1.31


### PR DESCRIPTION
Promote ubidy-messagequeueapi to version 0.1.54